### PR TITLE
Display app version

### DIFF
--- a/appVersion.js
+++ b/appVersion.js
@@ -1,3 +1,0 @@
-const appVersion = {
-    "versionNumber": "v24.7.0"
-}

--- a/appVersion.js
+++ b/appVersion.js
@@ -1,3 +1,3 @@
 const appVersion = {
-    versionNumber: 'v24.7.0'
+    "versionNumber": "v24.7.0"
 }

--- a/appVersion.js
+++ b/appVersion.js
@@ -1,0 +1,3 @@
+const appVersion = {
+    versionNumber: 'v24.7.0'
+}

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -340,3 +340,7 @@ table {
     border-radius: .25rem;
     width: 100px;
   }
+
+#appVersion {
+    font-size: 0.8rem;
+}

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
                     <li class="menu-item"><a class="footer-links" href="http://www.usa.gov/">USA.gov</a></li>
                 </ul>
                 <p class="menu footer-tagline">NIH…Turning Discovery Into Health<sup>®</sup></p>
+                <p id="appVersion"></p>
             </div>
         </div>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js" defer></script>

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ if ("serviceWorker" in navigator) {
     });
 }
 
-
 const datadogConfig = {
     clientToken: 'pubcb2a7770dcbc09aaf1da459c45ecff65',
     applicationId: '571977b4-ca80-4a04-b8fe-5d5148508afd',
@@ -1173,31 +1172,4 @@ const activityCheckController = () => {
     window.onload = resetTimer;
     document.onmousemove = resetTimer;
     document.onkeypress = resetTimer;
-};
-
-/**
- * This function is an async function that checks if the service worker is supported by the browser
- * If it is supported, it registers the service worker
- * If the service worker is already installed and there is a new service worker available, it refreshes the page
-*/
-const registerServiceWorker = async () => {
-    if ("serviceWorker" in navigator) {
-        try {
-            const registration = await navigator.serviceWorker.register("./serviceWorker.js");
-            console.log('Service Worker registered with scope:', registration.scope);
-
-            registration.addEventListener('updatefound', () => { // This event fires when a new service worker is found
-                const newWorker = registration.installing;
-                newWorker.addEventListener('statechange', () => { // This event fires when the state of the service worker changes
-                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                    // New content is available, refresh the page
-                    console.log("Refreshing page");
-                    window.location.reload();
-                }
-            });
-        });
-        } catch (error) {
-            console.log('Service Worker registration failed:', error);
-        }
-    }
 };

--- a/index.js
+++ b/index.js
@@ -1170,21 +1170,21 @@ const activityCheckController = () => {
 const registerServiceWorker = async () => {
     if ("serviceWorker" in navigator) {
         try {
-        const registration = await navigator.serviceWorker.register("./serviceWorker.js");
-        console.log('Service Worker registered with scope:', registration.scope);
+            const registration = await navigator.serviceWorker.register("./serviceWorker.js");
+            console.log('Service Worker registered with scope:', registration.scope);
 
-        registration.addEventListener('updatefound', () => { // This event fires when a new service worker is found
-            const newWorker = registration.installing;
-            newWorker.addEventListener('statechange', () => { // This event fires when the state of the service worker changes
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                // New content is available, refresh the page
-                console.log("Refreshing page");
-                window.location.reload();
-            }
+            registration.addEventListener('updatefound', () => { // This event fires when a new service worker is found
+                const newWorker = registration.installing;
+                newWorker.addEventListener('statechange', () => { // This event fires when the state of the service worker changes
+                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                    // New content is available, refresh the page
+                    console.log("Refreshing page");
+                    window.location.reload();
+                }
             });
         });
         } catch (error) {
-        console.log('Service Worker registration failed:', error);
+            console.log('Service Worker registration failed:', error);
         }
     }
 };

--- a/index.js
+++ b/index.js
@@ -41,6 +41,14 @@ const isLocalDev = location.hostname === 'localhost' || location.hostname === '1
 const statsDataTimeLimit = 1200000; // 20 minutes
 
 window.onload = async () => {
+
+    try{
+        registerServiceWorker();
+        updateVersionDisplay();
+    } catch (error) {
+        console.log('Service Worker registration failed:', error);
+    }
+
     if(location.host === urls.prod) {
         !firebase.apps.length ? firebase.initializeApp(prodFirebaseConfig) : firebase.app();
         window.DD_RUM && window.DD_RUM.init({ ...datadogConfig, env: 'prod' });
@@ -1155,11 +1163,68 @@ const activityCheckController = () => {
     document.onkeypress = resetTimer;
 };
 
-// Add version number to footer
-document.addEventListener('DOMContentLoaded', function() {
-    const contentWrapper = document.querySelector('.footer-content .content-wrapper');
+/**
+ * This function is an async function that checks if the service worker is supported by the browser
+ * If it is supported, it registers the service worker
+ * If the service worker is already installed and there is a new service worker available, it refreshes the page
+*/
+const registerServiceWorker = async () => {
+    if ("serviceWorker" in navigator) {
+        try {
+        const registration = await navigator.serviceWorker.register("./serviceWorker.js");
+        console.log('Service Worker registered with scope:', registration.scope);
 
-    const newElement = document.createElement('div');
-    newElement.innerHTML = `<p id="appVersion">${appVersion.versionNumber}</p>`;
-    contentWrapper.appendChild(newElement);
-});
+        registration.addEventListener('updatefound', () => { // This event fires when a new service worker is found
+            const newWorker = registration.installing;
+            newWorker.addEventListener('statechange', () => { // This event fires when the state of the service worker changes
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                // New content is available, refresh the page
+                console.log("Refreshing page");
+                window.location.reload();
+            }
+            });
+        });
+        } catch (error) {
+        console.log('Service Worker registration failed:', error);
+        }
+    }
+};
+
+/**
+ * Fetches the app version from the cache storage and updates the version display in the footer
+*/
+const updateVersionDisplay = async () => {
+    const versionNumber = await fetchAppVersionFromCache();
+    if (!versionNumber) return;
+
+    let versionElement = document.getElementById('appVersion');
+
+    if (!versionElement) { 
+        const contentWrapper = document.querySelector('.footer-content .content-wrapper');
+        if (!contentWrapper || !versionNumber) return;
+
+        versionElement = document.createElement('p');
+        versionElement.id = 'appVersion';
+        contentWrapper.appendChild(versionElement);
+        versionElement.textContent = versionNumber;
+    }
+};
+
+const fetchAppVersionFromCache = async () => {
+    try {
+        const cache = await caches.open('app-version-cache');
+        const response = await cache.match('./appVersion.js');
+
+        if (!response) return;
+
+        const appVersionText = await response.text();
+        const versionMatch = appVersionText.match(/"versionNumber"\s*:\s*"(v\d+\.\d+\.\d+)"/);
+
+        if (!versionMatch) return;
+
+        return versionMatch[1];
+    } catch (error) {
+        console.error('Error fetching app version:', error);
+        return 'Error fetching version';
+    }
+};

--- a/index.js
+++ b/index.js
@@ -1154,3 +1154,12 @@ const activityCheckController = () => {
     document.onmousemove = resetTimer;
     document.onkeypress = resetTimer;
 };
+
+// Add version number to footer
+document.addEventListener('DOMContentLoaded', function() {
+    const contentWrapper = document.querySelector('.footer-content .content-wrapper');
+
+    const newElement = document.createElement('div');
+    newElement.innerHTML = `<p id="appVersion">${appVersion.versionNumber}</p>`;
+    contentWrapper.appendChild(newElement);
+});

--- a/index.js
+++ b/index.js
@@ -41,9 +41,8 @@ const isLocalDev = location.hostname === 'localhost' || location.hostname === '1
 const statsDataTimeLimit = 1200000; // 20 minutes
 
 window.onload = async () => {
-
     try{
-        registerServiceWorker();
+        registerServiceWorker(); 
         updateVersionDisplay();
     } catch (error) {
         console.log('Service Worker registration failed:', error);

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,26 +1,51 @@
-importScripts('./appVersion.js');
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox-sw.js');
 
-const cacheVersionName = `app-version-cache`;
-const precacheVersionAssets = ['/appVersion.js'];
+const appVersion = "v24.7.0";
+workbox.setConfig({ debug: false });
+const { registerRoute } = workbox.routing;
+const { CacheFirst, NetworkFirst } = workbox.strategies;
+const { ExpirationPlugin } = workbox.expiration;
 
-self.addEventListener('install', (event) => {
+const cacheNameMapper = {
+    "static-cache": `static-cache-${appVersion}`,
+    "images-cache": `images-cache-${appVersion}`,
+};
+
+const currCacheNameArray = Object.values(cacheNameMapper);
+
+registerRoute(/\.(?:js|css|html)$/, new NetworkFirst({ cacheName: cacheNameMapper["static-cache"] }));
+registerRoute(/\.(?:png|jpg|jpeg|svg|gif|ico)$/,
+    new CacheFirst({
+        cacheName: cacheNameMapper["images-cache"],
+        plugins: [
+            new ExpirationPlugin({
+                maxEntries: 30,
+                maxAgeSeconds: 7 * 24 * 60 * 60,
+            })
+        ]
+    })
+);
+
+self.addEventListener("install", () => {
+    self.skipWaiting();
+  });
+  
+  self.addEventListener("activate", (event) => {
     event.waitUntil(
-        caches.open(cacheVersionName)
-            .then((cache) => {
-                return cache.keys()
-                    .then((keys) => {
-                        const deletionPromises = keys
-                            .filter(key => key.url.includes('app-version-cache')) //
-                            .map(key => cache.delete(key));
-                            return Promise.all(deletionPromises);
+        caches.keys().then((cacheNames) => {
+            return Promise.all(
+            cacheNames.map((cacheName) => {
+                if (!currCacheNameArray.includes(cacheName)) {
+                    return caches.delete(cacheName);
+            }
             })
-            .then(() => cache.addAll(precacheVersionAssets));
-            })
-            .then(() => {
-                self.skipWaiting(); // Forces the waiting service worker to become the active service worker
-            })
-            .catch(error => {
-                console.error('Cache update failed:', error);
-            })
+        );
+        })
     );
+});
+  
+self.addEventListener("message", (event) => {
+    if (event.data.action === "getAppVersion") {
+        event.source.postMessage({ action: "sendAppVersion", payload: appVersion });
+    }
 });

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -13,7 +13,7 @@ const cacheNameMapper = {
 
 const currCacheNameArray = Object.values(cacheNameMapper);
 
-registerRoute(/\.(?:js|css|html)$/, new NetworkFirst({ cacheName: cacheNameMapper["static-cache"] }));
+registerRoute(/\.(?:js|css|html|pdf)$/, new NetworkFirst({ cacheName: cacheNameMapper["static-cache"] }));
 registerRoute(/\.(?:png|jpg|jpeg|svg|gif|ico)$/,
     new CacheFirst({
         cacheName: cacheNameMapper["images-cache"],

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,0 +1,26 @@
+importScripts('./appVersion.js');
+
+const cacheVersionName = `app-version-cache`;
+const precacheVersionAssets = ['/appVersion.js'];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(cacheVersionName)
+            .then((cache) => {
+                return cache.keys()
+                    .then((keys) => {
+                        const deletionPromises = keys
+                            .filter(key => key.url.includes('app-version-cache')) //
+                            .map(key => cache.delete(key));
+                            return Promise.all(deletionPromises);
+            })
+            .then(() => cache.addAll(precacheVersionAssets));
+            })
+            .then(() => {
+                self.skipWaiting(); // Forces the waiting service worker to become the active service worker
+            })
+            .catch(error => {
+                console.error('Cache update failed:', error);
+            })
+    );
+});


### PR DESCRIPTION
This pull request is related to the following:
- https://github.com/episphere/connect/issues/621
 
Related pull requests:
- https://github.com/episphere/biospecimen/pull/730
- https://github.com/episphere/connectApp/pull/813

Problem: Display the app version number

Code changes ([Warren's push changes and other small fixes](https://github.com/episphere/biospecimen/pull/730/commits/5ef27c3175a0c44d0ab129e0c44a1a47b58d5034)):

- In `index.html`, script for using sentry removed
- In `index.js`, service worker conditional with listeners to check if service worker is registered and to have main thread and service worker to communicate to get the app version
- In `serviceWorkers.js`, add version number be in a constant; add cache version number in register route for `NetworkFirst` and `CacheFirst` Strategy; include listener to install a new service worker immediately skipping waiting phase , listener to remove old cache when new service worker activates, and event listener to respond to the main thread asking for "getAppVersion" to display version number to footer