### PR TITLE
Incentive eligibility update error alert

### DIFF
--- a/src/dataCorrectionsTool/incentiveEligibilityTool.js
+++ b/src/dataCorrectionsTool/incentiveEligibilityTool.js
@@ -8,6 +8,7 @@ import { findParticipant } from '../participantLookup.js';
 let participantPaymentRound = null;
 let isEligibleForIncentiveUpdate = null;
 let selectedDateOfEligibility = null; // YYYY-MM-DD
+let isConfirmListenerAdded = false;
 
 const conceptIdToPaymentRoundMapping = {
     266600170: 'baseline',
@@ -143,7 +144,7 @@ const handlePaymentRoundSelect = (participant) => {
     const { paymentRound, baselinePayment, eligiblePayment, norcPaymentEligibility, no } = fieldMapping; 
 
     for (let option of dropdownPaymentOptions) {
-        option.addEventListener('click', async (e) => { // TODO: Add gaurd to prevent multiple event listeners from being added
+        option.addEventListener('click', async (e) => {
             participantPaymentRound = e.target.dataset.payment;
             if (participantPaymentRound === fieldMapping['baseline'].toString()) {
                 selectButton.textContent = e.target.textContent;
@@ -163,7 +164,11 @@ const handlePaymentRoundSelect = (participant) => {
                         displaySetDateOfEligibilityContent();
                         setIncentiveEligibleInputDefaultValue();
                         handleParticipantPaymentTextContent(participantData, isEligibleForIncentiveUpdate);
-                        confirmIncentiveEligibilityUpdate(participant);
+                        // prevent multiple event listeners from being added
+                        if (!isConfirmListenerAdded) {
+                            confirmIncentiveEligibilityUpdate(participant);
+                            isConfirmListenerAdded = true;
+                        }
                         dateOfEligibilityInput.disabled = false;
                     } else {
                         toggleSubmitButton();
@@ -267,15 +272,10 @@ const toggleSubmitButton = (isEligibleForIncentiveUpdate) => {
 };
 
 const confirmIncentiveEligibilityUpdate = (participant) => { 
-    let confirmButton = document.getElementById('confirmUpdateEligibility');
+    const confirmButton = document.getElementById('confirmUpdateEligibility');
     const { paymentRound, baseline, eligiblePaymentRoundTimestamp } = fieldMapping;
 
     if (confirmButton && dateOfEligibilityInput) {
-        // Replace button and reassign the reference to clean up event listeners
-        const newConfirmButton = confirmButton.cloneNode(true);
-        confirmButton.replaceWith(newConfirmButton);
-        confirmButton = newConfirmButton;
-
         confirmButton.addEventListener('click', async (e) => {
             const confirmUpdateEligibilityButton = document.getElementById('confirmUpdateEligibility');
             const selectedDateValue = selectedDateOfEligibility ? convertToISO8601(selectedDateOfEligibility) : convertToISO8601(dateOfEligibilityInput.value);

--- a/src/dataCorrectionsTool/incentiveEligibilityTool.js
+++ b/src/dataCorrectionsTool/incentiveEligibilityTool.js
@@ -267,10 +267,15 @@ const toggleSubmitButton = (isEligibleForIncentiveUpdate) => {
 };
 
 const confirmIncentiveEligibilityUpdate = (participant) => { 
-    const confirmButton = document.getElementById('confirmUpdateEligibility');
+    let confirmButton = document.getElementById('confirmUpdateEligibility');
     const { paymentRound, baseline, eligiblePaymentRoundTimestamp } = fieldMapping;
 
     if (confirmButton && dateOfEligibilityInput) {
+        // Replace button and reassign the reference to clean up event listeners
+        const newConfirmButton = confirmButton.cloneNode(true);
+        confirmButton.replaceWith(newConfirmButton);
+        confirmButton = newConfirmButton;
+
         confirmButton.addEventListener('click', async (e) => {
             const confirmUpdateEligibilityButton = document.getElementById('confirmUpdateEligibility');
             const selectedDateValue = selectedDateOfEligibility ? convertToISO8601(selectedDateOfEligibility) : convertToISO8601(dateOfEligibilityInput.value);

--- a/src/dataCorrectionsTool/incentiveEligibilityTool.js
+++ b/src/dataCorrectionsTool/incentiveEligibilityTool.js
@@ -8,7 +8,7 @@ import { findParticipant } from '../participantLookup.js';
 let participantPaymentRound = null;
 let isEligibleForIncentiveUpdate = null;
 let selectedDateOfEligibility = null; // YYYY-MM-DD
-let isConfirmListenerAdded = false;
+let handleConfirmClickWrapper = null; // reference to handleConfirmClick function
 
 const conceptIdToPaymentRoundMapping = {
     266600170: 'baseline',
@@ -164,11 +164,7 @@ const handlePaymentRoundSelect = (participant) => {
                         displaySetDateOfEligibilityContent();
                         setIncentiveEligibleInputDefaultValue();
                         handleParticipantPaymentTextContent(participantData, isEligibleForIncentiveUpdate);
-                        // prevent multiple event listeners from being added
-                        if (!isConfirmListenerAdded) {
-                            confirmIncentiveEligibilityUpdate(participant);
-                            isConfirmListenerAdded = true;
-                        }
+                        confirmIncentiveEligibilityUpdate(participant);
                         dateOfEligibilityInput.disabled = false;
                     } else {
                         toggleSubmitButton();
@@ -273,34 +269,43 @@ const toggleSubmitButton = (isEligibleForIncentiveUpdate) => {
 
 const confirmIncentiveEligibilityUpdate = (participant) => { 
     const confirmButton = document.getElementById('confirmUpdateEligibility');
-    const { paymentRound, baseline, eligiblePaymentRoundTimestamp } = fieldMapping;
-
     if (confirmButton && dateOfEligibilityInput) {
-        confirmButton.addEventListener('click', async (e) => {
-            const confirmUpdateEligibilityButton = document.getElementById('confirmUpdateEligibility');
-            const selectedDateValue = selectedDateOfEligibility ? convertToISO8601(selectedDateOfEligibility) : convertToISO8601(dateOfEligibilityInput.value);
-            if (confirmUpdateEligibilityButton) {
-                try {
-                    const updateResponse = await updateParticipantIncentiveEligibility(participant, participantPaymentRound, selectedDateValue);
-                    const currentParticipantData = updateResponse.data;
-
-                    if (updateResponse.code === 200) { 
-                        triggerNotificationBanner("Participant incentive eligibility status updated successfully!", "success" ,14000);
-                        localStorage.setItem('participant', JSON.stringify(currentParticipantData));
-                        document.getElementById('incentiveStatusText').textContent = 'Incentive Eligibility Status: Eligible';
-                        document.getElementById('isIncentiveEligibleNote').innerHTML = `<span><i class="fas fa-check-square fa-lg" style="color: #4CAF50; background: white;"></i> This participant is already incentive eligible. The eligibility status cannot be updated.</span>`;
-                        document.getElementById('dateOfEligibilityText').textContent = `Date of Eligibility: ${formatUTCDate(currentParticipantData?.[paymentRound]?.[baseline]?.[eligiblePaymentRoundTimestamp])}`; // TODO: Add flexibility for other payment rounds
-                        removeSetDateOfEligibilityContent();
-                        toggleSubmitButton();
-                    }
-                } catch (error) { 
-                    console.error("Failed to update participant incentive eligibility: ", error);
-                    triggerNotificationBanner(`${error.message}`, 'danger', 14000);
-                } 
-            }
-        });
+        // Check if the wrapper already exists; if not, create it
+        if (!handleConfirmClickWrapper) {
+            handleConfirmClickWrapper = () => handleConfirmClick(participant);
+        }
+        // remove and add listeners to prevent multiple listeners
+        confirmButton.removeEventListener('click', handleConfirmClickWrapper);
+        confirmButton.addEventListener('click', handleConfirmClickWrapper);
     }
-}
+};
+
+const handleConfirmClick = async (participant) => { 
+    const { paymentRound, baseline, eligiblePaymentRoundTimestamp } = fieldMapping;
+    const confirmUpdateEligibilityButton = document.getElementById('confirmUpdateEligibility');
+    const selectedDateValue = selectedDateOfEligibility ? convertToISO8601(selectedDateOfEligibility) : convertToISO8601(dateOfEligibilityInput.value);
+
+    if (confirmUpdateEligibilityButton) {
+        try {
+            const updateResponse = await updateParticipantIncentiveEligibility(participant, participantPaymentRound, selectedDateValue);
+            const currentParticipantData = updateResponse.data;
+
+            if (updateResponse.code === 200) { 
+                triggerNotificationBanner("Participant incentive eligibility status updated successfully!", "success" ,14000);
+                localStorage.setItem('participant', JSON.stringify(currentParticipantData));
+                document.getElementById('incentiveStatusText').textContent = 'Incentive Eligibility Status: Eligible';
+                document.getElementById('isIncentiveEligibleNote').innerHTML = `<span><i class="fas fa-check-square fa-lg" style="color: #4CAF50; background: white;"></i> This participant is already incentive eligible. The eligibility status cannot be updated.</span>`;
+                document.getElementById('dateOfEligibilityText').textContent = `Date of Eligibility: ${formatUTCDate(currentParticipantData?.[paymentRound]?.[baseline]?.[eligiblePaymentRoundTimestamp])}`; // TODO: Add flexibility for other payment rounds
+                removeSetDateOfEligibilityContent();
+            }
+        } catch (error) { 
+            console.error("Failed to update participant incentive eligibility: ", error);
+            triggerNotificationBanner(`${error.message}`, 'danger', 14000);
+        } finally {
+            toggleSubmitButton();
+        }
+    }
+};
 
 const setupModalContent = (participantPaymentRound) => {
     const paymentRoundType = conceptIdToPaymentRoundMapping[participantPaymentRound];


### PR DESCRIPTION
This pull request is related to 
- https://github.com/episphere/connect/issues/1130
- https://github.com/episphere/connect/issues/1131

Problem:
 - Duplicate event listeners are being added to the confirm button. This is causing the confirm button to make multiple POST requests.

Code:
- Extracted handler logic to an outside function for modularity. 
- Added removeEventListener to `confirmIncentiveEligibilityUpdate`
- Added finally block to disable the submit button
